### PR TITLE
fix(lint): allow global expect

### DIFF
--- a/generators/lint/templates/eslintrc
+++ b/generators/lint/templates/eslintrc
@@ -1,3 +1,6 @@
 {
-  extends: "lob"
+  extends: "lob",
+  globals: {
+    expect: false
+  }
 }


### PR DESCRIPTION
Modify the `.eslintrc` template to allow global `expect`s since the `test/setup.js` file generated by `yo lob:test` initializes one.