### PR TITLE
feat(config): creates a lob:config sub-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To generate a portion of a repository, you may use a [sub-generator](#sub-genera
 
 ## Sub-Generators
 
+**Config** [`yo lob:config`](#config)
+
 **Continuous Integration** [`yo lob:ci`](#continuous-integration)
 
 **Lint** [`yo lob:lint`](#lint)
@@ -28,6 +30,15 @@ To generate a portion of a repository, you may use a [sub-generator](#sub-genera
 **Release** [`yo lob:release`](#release)
 
 **Test** [`yo lob:test`](#test)
+
+### Config
+
+```
+$ yo lob:config
+```
+
+- Prompts for whether to generate a `config` directory
+- Generates a `config/index.js` file that reads an object of config variables from one of `config/developments.js`, `config/production.js`, `config/staging.js`, or `config/test.js` based on the `NODE_ENV`. Initializes each environment's config file to export an empty object.
 
 ### Continuous Integration
 

--- a/generators/config/index.js
+++ b/generators/config/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Generators = require('yeoman-generator');
+
+module.exports = Generators.Base.extend({
+  initializing: function () {
+    this.props = {};
+  },
+  prompting: function () {
+    const done = this.async();
+
+    this.prompt([{
+      name: 'config',
+      message: 'Generate config directory?',
+      type: 'confirm',
+      required: true,
+      default: true
+    }], (props) => {
+      this.props = props;
+      done();
+    });
+  },
+  writing: function () {
+    if (!this.props.config) {
+      return;
+    }
+
+    this.fs.copyTpl(this.templatePath('index.js'), this.destinationPath('config/index.js'));
+    this.fs.copyTpl(this.templatePath('environment.js'), this.destinationPath('config/development.js'));
+    this.fs.copyTpl(this.templatePath('environment.js'), this.destinationPath('config/production.js'));
+    this.fs.copyTpl(this.templatePath('environment.js'), this.destinationPath('config/staging.js'));
+    this.fs.copyTpl(this.templatePath('environment.js'), this.destinationPath('config/test.js'));
+  }
+});

--- a/generators/config/templates/environment.js
+++ b/generators/config/templates/environment.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  FOO: 'bar'
+};

--- a/generators/config/templates/index.js
+++ b/generators/config/templates/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const config =  {
+  development: require('./development'),
+  production: require('./production'),
+  staging: require('./staging'),
+  test: require('./test')
+};
+
+/* istanbul ignore next */
+module.exports = config[process.env.NODE_ENV || 'development'];

--- a/generators/index.js
+++ b/generators/index.js
@@ -5,6 +5,7 @@ const Generators = require('yeoman-generator');
 module.exports = Generators.Base.extend({
   initializing: function () {
     this.composeWith('lob:ci');
+    this.composeWith('lob:config');
     this.composeWith('lob:lint');
     this.composeWith('lob:node-version');
     this.composeWith('lob:release');

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   ci: require('./generators/ci'),
+  config: require('./generators/config'),
   lint: require('./generators/lint'),
   node_version: require('./generators/node-version'),
   release: require('./generators/release'),

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const Assert = require('yeoman-assert');
+const Path   = require('path');
+const Yo     = require('yeoman-test');
+
+describe('lob:config', () => {
+
+  describe('yes', () => {
+
+    beforeEach((done) => {
+      Yo.run(Path.join(__dirname, '../generators/config'))
+        .withPrompts({ config: true })
+        .on('end', done);
+    });
+
+    it('creates config/index.js', () => {
+      Assert.file('config/index.js');
+    });
+
+    it('creates config/development.js', () => {
+      Assert.file('config/development.js');
+    });
+
+    it('creates config/production.js', () => {
+      Assert.file('config/production.js');
+    });
+
+    it('creates config/staging.js', () => {
+      Assert.file('config/staging.js');
+    });
+
+    it('creates config/test.js', () => {
+      Assert.file('config/test.js');
+    });
+
+  });
+
+  describe('no', () => {
+
+    beforeEach((done) => {
+      Yo.run(Path.join(__dirname, '../generators/config'))
+        .withPrompts({ config: false })
+        .on('end', done);
+    });
+
+    it('does not generate a config directory', () => {
+      Assert.noFile([
+        'config/index.js',
+        'config/development.js',
+        'config/production.js',
+        'config/staging.js',
+        'config/test.js'
+      ]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
### What 

Creates a `yo lob:config` sub-generator. See updated readme for details.

### Why

Almost all of our projects use a config directory. Plus the training API project requires a config directory so adding this now is especially timely for that.