### PR TITLE
fix(test): send NODE_ENV to 'test' in test scripts

### DIFF
--- a/generators/test/index.js
+++ b/generators/test/index.js
@@ -15,8 +15,8 @@ module.exports = Generators.Base.extend({
       },
       scripts: {
         enforce: 'istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100',
-        test: 'istanbul cover _mocha -- test --require test/setup.js --recursive --timeout 30000',
-        'test:raw': 'mocha test --require test/setup.js --recursive --timeout 30000'
+        test: 'NODE_ENV=test istanbul cover _mocha -- test --require test/setup.js --recursive --timeout 30000',
+        'test:raw': 'NODE_ENV=test mocha test --require test/setup.js --recursive --timeout 30000'
       }
     });
 


### PR DESCRIPTION
This ensures that tests run locally use the "test" `NODE_ENV`.