### PR TITLE
fix(node-version): Add trailing newline to generated .node-version file.

### DIFF
--- a/generators/node-version/index.js
+++ b/generators/node-version/index.js
@@ -17,6 +17,6 @@ module.exports = Generators.Base.extend({
     });
   },
   writing: function () {
-    this.fs.write(this.destinationPath('.node-version'), this.version.toString());
+    this.fs.write(this.destinationPath('.node-version'), `${this.version.toString()}\n`);
   }
 });


### PR DESCRIPTION
What: Update `.node-version` generator to include a trailing newline character.

Why: This ensures that the generated `.node-version` file passes lint tests and meets POSIX standards, which defines a line as a series of zero or more non-newline characters followed by a newline character.

Notes:
- Addresses #7 