### PR TITLE
fix(ci): set NODE_ENV to test in travis.yml

### DIFF
--- a/generators/ci/templates/travis.yml
+++ b/generators/ci/templates/travis.yml
@@ -2,6 +2,8 @@ language: node_js
 sudo: false
 node_js:
   - <%= version %>
+env:
+  - NODE_ENV="test"
 script:
   - npm test
   - npm run enforce


### PR DESCRIPTION
If you wanted to add db setup scripts like `npm run db:migrate` in your travis build, they rely on the `NODE_ENV` being set to `test` in order to pull from the `config/test.js` file.